### PR TITLE
File dialog cursors

### DIFF
--- a/CogsPartyLauncher/scenes/main.tscn
+++ b/CogsPartyLauncher/scenes/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=3 uid="uid://k31chn02rvs2"]
+[gd_scene load_steps=32 format=3 uid="uid://k31chn02rvs2"]
 
 [ext_resource type="Theme" uid="uid://036n6qd3ik2g" path="res://assets/theme.tres" id="1_erdau"]
 [ext_resource type="Script" uid="uid://du6vnjc42pp0f" path="res://scripts/main_menu.gd" id="2_6njpl"]
@@ -93,6 +93,14 @@ corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
+
+[sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_yc10j"]
+
+[sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_jscy8"]
+
+[sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_pm3ni"]
+
+[sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_y6deb"]
 
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_muem4"]
 
@@ -435,10 +443,39 @@ layout_mode = 2
 text = "E D I T"
 
 [node name="GamesFolderSelectFileDialog" type="FileDialog" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton"]
+oversampling_override = 1.0
 title = "Open a Directory"
 ok_button_text = "Select Current Folder"
 file_mode = 2
 access = 2
+
+[node name="BottomBorder" type="StaticBody2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog"]
+position = Vector2(599, 562)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog/BottomBorder"]
+shape = SubResource("WorldBoundaryShape2D_yc10j")
+
+[node name="TopBorder" type="StaticBody2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog"]
+position = Vector2(613, 514)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog/TopBorder"]
+position = Vector2(1, -533)
+rotation = 3.1415927
+shape = SubResource("WorldBoundaryShape2D_jscy8")
+
+[node name="RightBorder" type="StaticBody2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog"]
+position = Vector2(966, 288)
+rotation = -1.5707964
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog/RightBorder"]
+shape = SubResource("WorldBoundaryShape2D_pm3ni")
+
+[node name="StaticBody2D" type="StaticBody2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog"]
+position = Vector2(-23, 282)
+rotation = 1.5707964
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog/StaticBody2D"]
+shape = SubResource("WorldBoundaryShape2D_y6deb")
 
 [node name="GamesFolderLabel" type="Label" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer"]
 layout_mode = 2

--- a/CogsPartyLauncher/scenes/main.tscn
+++ b/CogsPartyLauncher/scenes/main.tscn
@@ -450,7 +450,7 @@ file_mode = 2
 access = 2
 
 [node name="BottomBorder" type="StaticBody2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog"]
-position = Vector2(599, 562)
+position = Vector2(599, 638)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog/BottomBorder"]
 shape = SubResource("WorldBoundaryShape2D_yc10j")
@@ -464,17 +464,17 @@ rotation = 3.1415927
 shape = SubResource("WorldBoundaryShape2D_jscy8")
 
 [node name="RightBorder" type="StaticBody2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog"]
-position = Vector2(966, 288)
+position = Vector2(1115, 288)
 rotation = -1.5707964
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog/RightBorder"]
 shape = SubResource("WorldBoundaryShape2D_pm3ni")
 
-[node name="StaticBody2D" type="StaticBody2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog"]
+[node name="LeftBorder" type="StaticBody2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog"]
 position = Vector2(-23, 282)
 rotation = 1.5707964
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog/StaticBody2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer/GamesFolderSelectButton/GamesFolderSelectFileDialog/LeftBorder"]
 shape = SubResource("WorldBoundaryShape2D_y6deb")
 
 [node name="GamesFolderLabel" type="Label" parent="Menus/MainMenu/VBoxContainer/PanelContainer/MarginContainer/VBoxContainer/VBoxContainer/MarginContainer"]

--- a/CogsPartyLauncher/scripts/main_menu.gd
+++ b/CogsPartyLauncher/scripts/main_menu.gd
@@ -66,7 +66,9 @@ func _on_refresh_games_button_pressed():
 
 
 func _on_games_folder_select_pressed():
-	games_folder_select_file_dialog.popup_centered_ratio()
+	# NOTE: if you change this, you will also need to adjust the WorldBorders containing the cursors
+	# under the GamesFolderSelectFileDialog
+	games_folder_select_file_dialog.popup_centered_ratio(0.93)
 	
 
 func _on_games_folder_selected(folder: String):

--- a/CogsPartyLauncher/scripts/player_cursor.gd
+++ b/CogsPartyLauncher/scripts/player_cursor.gd
@@ -47,10 +47,11 @@ func _physics_process(delta):
 func _input(event: InputEvent) -> void:
 	if controller_id != -1:
 		if event.is_action_pressed("select%s" % [controller_id]):
-				if elapsed_time - last_click <= DOUBLE_CLICK_THRESHOLD:
-					_simulate_mouse_click(true)
-				else:
-					_simulate_mouse_click(false)
+			if elapsed_time - last_click <= DOUBLE_CLICK_THRESHOLD:
+				_simulate_mouse_click(true)
+				last_click = 0
+			else:
+				_simulate_mouse_click(false)
 				last_click = elapsed_time
 
 

--- a/CogsPartyLauncher/scripts/player_cursor.gd
+++ b/CogsPartyLauncher/scripts/player_cursor.gd
@@ -6,6 +6,9 @@ extends CharacterBody2D
 # unlinked cursors have an ID of -1
 var controller_id: int = 0
 
+# reference to a matching cursor used to navigate the file dialog from the edit button on the main menu
+var file_dialog_cursor: CharacterBody2D
+
 
 func construct(cursor_position: Vector2, id: int):
 	position = cursor_position
@@ -33,6 +36,10 @@ func _physics_process(delta):
 		else:
 			_simulate_stop_scroll(MOUSE_BUTTON_WHEEL_UP)
 			_simulate_stop_scroll(MOUSE_BUTTON_WHEEL_DOWN)
+
+
+func get_id() -> int:
+	return controller_id
 
 
 func _input(event: InputEvent) -> void:
@@ -77,7 +84,17 @@ func _simulate_stop_scroll(direction: MouseButton):
 
 func update_player_label(player_number: int):
 	player_name_label.text = "P%d" % player_number
+	if file_dialog_cursor != null:
+		file_dialog_cursor.update_player_label(player_number)
 
 
 func update_color(color: Color):
 	$Sprite2D.modulate = color
+	if file_dialog_cursor != null:
+		file_dialog_cursor.update_color(color)
+
+
+func update_id(id: int):
+	controller_id = id
+	if file_dialog_cursor != null:
+		file_dialog_cursor.update_id(id)

--- a/CogsPartyLauncher/scripts/player_select_menu.gd
+++ b/CogsPartyLauncher/scripts/player_select_menu.gd
@@ -182,10 +182,12 @@ func _on_player_setting_removed(player_setting: PlayerSetting):
 	else:
 		pass # next_focus_control.grab_focus()
 		
-	# delete cursor
-	_remove_taken_id(player_setting.player_cursor.controller_id)
+	# delete cursor and its file dialog duplicate
+	_remove_taken_id(player_setting.player_cursor.get_id())
 	player_cursors.erase(player_setting.player_cursor)
+	player_setting.player_cursor.file_dialog_cursor.queue_free()
 	player_setting.player_cursor.queue_free()
+	
 
 	player_setting_container.remove_child(player_setting)
 	player_setting.queue_free()
@@ -210,12 +212,14 @@ func _create_new_cursor() -> CharacterBody2D:
 
 func _create_file_dialog_cursor(player_cursor: CharacterBody2D):
 	var file_dialog_cursor = player_cursor.duplicate()
-	var controller_id: int = player_cursor.controller_id
 	var main_menu = get_tree().current_scene.find_child("Menus").find_child("MainMenu")
+	
+	# gives the original player cursor a reference to the duplicate used in the file dialog
+	player_cursor.file_dialog_cursor = file_dialog_cursor
 	
 	file_dialog_cursor.construct(
 		Vector2(randi_range(476,676), randi_range(224,424)),
-		controller_id
+		player_cursor.get_id()
 	)
 	if main_menu != null:
 		main_menu.games_folder_select_file_dialog.add_child(file_dialog_cursor)
@@ -240,11 +244,11 @@ func _reset_controller_ids():
 	
 	taken_ids.clear()
 	for cursor in player_cursors:
-		cursor.controller_id = -1
+		cursor.update_id(-1)
 		for device in devices:
 			if not taken_ids.has(device):
 				taken_ids[device] = null
-				cursor.controller_id = device
+				cursor.update_id(device)
 				break
 
 

--- a/CogsPartyLauncher/scripts/player_select_menu.gd
+++ b/CogsPartyLauncher/scripts/player_select_menu.gd
@@ -155,17 +155,7 @@ func _on_player_count_changed():
 
 
 func _on_add_player_button_pressed():
-	var main = get_tree().current_scene
-	var player_cursor = player_cursor_prefab.instantiate() as CharacterBody2D
-	var id = _get_next_id()
-	_add_taken_id(id)
-	player_cursor.construct(
-		Vector2(randi_range(476,676), randi_range(224,424)),
-		id
-	)
-	player_cursors.append(player_cursor)
-	main.add_child.call_deferred(player_cursor)
-	
+	var player_cursor = _create_new_cursor()
 	
 	var inst = player_setting_prefab.instantiate() as PlayerSetting
 	player_setting_container.add_child(inst)
@@ -178,6 +168,7 @@ func _on_add_player_button_pressed():
 		_get_next_available_color_or_self()
 	)
 	player_settings.append(inst)
+	_create_file_dialog_cursor(player_cursor)
 	_on_player_count_changed()
 
 
@@ -201,6 +192,33 @@ func _on_player_setting_removed(player_setting: PlayerSetting):
 	player_settings.erase(player_setting)
 	_reset_controller_ids()
 	_on_player_count_changed()
+
+
+func _create_new_cursor() -> CharacterBody2D:
+	var player_cursor = player_cursor_prefab.instantiate() as CharacterBody2D
+	var id = _get_next_id()
+	_add_taken_id(id)
+	
+	player_cursor.construct(
+		Vector2(randi_range(476,676), randi_range(224,424)),
+		id
+	)
+	player_cursors.append(player_cursor)
+	get_tree().current_scene.add_child.call_deferred(player_cursor)
+	return player_cursor
+
+
+func _create_file_dialog_cursor(player_cursor: CharacterBody2D):
+	var file_dialog_cursor = player_cursor.duplicate()
+	var controller_id: int = player_cursor.controller_id
+	var main_menu = get_tree().current_scene.find_child("Menus").find_child("MainMenu")
+	
+	file_dialog_cursor.construct(
+		Vector2(randi_range(476,676), randi_range(224,424)),
+		controller_id
+	)
+	if main_menu != null:
+		main_menu.games_folder_select_file_dialog.add_child(file_dialog_cursor)
 
 
 func _on_joy_connection_changed(device_id: int, connected: bool):

--- a/CogsPartyLauncher/scripts/player_select_menu.gd
+++ b/CogsPartyLauncher/scripts/player_select_menu.gd
@@ -31,6 +31,7 @@ func _ready():
 	_update_add_player_button()
 	_get_non_ui_controls()
 	
+	
 	for device in Input.get_connected_joypads():
 		_add_controls(device)
 		_on_add_player_button_pressed()


### PR DESCRIPTION
Adds a duplicate cursor for every player that can be used to navigate the "Edit Folder" file dialog. Cursors can now double click, and I also cleaned up some of code I previously changed in the player select menu script. 

I forgot to open this request when I finished it a few weeks ago my bad 😭 